### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: release
 
 # on events


### PR DESCRIPTION
Potential fix for [https://github.com/mertzjames/go-seekr/security/code-scanning/1](https://github.com/mertzjames/go-seekr/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best way to do this is to add the block at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is likely `contents: read`, as the jobs only check out code and upload artifacts, not modifying repository contents. No changes to the steps or jobs are needed—just the addition of the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
